### PR TITLE
Fix documents portal not being launched

### DIFF
--- a/interfaces/builtin/desktop.go
+++ b/interfaces/builtin/desktop.go
@@ -269,18 +269,28 @@ dbus (receive, send)
 # The portals service is normally running and newer versions of
 # xdg-desktop-portal include AssumedAppArmor=unconfined. Since older
 # systems don't have this and because gtkfilechoosernativeportal.c relies on
-# service activation, allow sends to peer=(name=org.freedesktop.portal.Desktop)
+# service activation, allow sends to peer=(name=org.freedesktop.portal.{Desktop,Documents})
 # for service activation.
 dbus (send)
     bus=session
     interface=org.freedesktop.portal.*
-    path=/org/freedesktop/portal/{desktop,documents}{,/**}
+    path=/org/freedesktop/portal/desktop{,/**}
     peer=(name=org.freedesktop.portal.Desktop),
 dbus (send)
     bus=session
     interface=org.freedesktop.DBus.Properties
-    path=/org/freedesktop/portal/{desktop,documents}{,/**}
+    path=/org/freedesktop/portal/desktop{,/**}
     peer=(name=org.freedesktop.portal.Desktop),
+dbus (send)
+    bus=session
+    interface=org.freedesktop.portal.*
+    path=/org/freedesktop/portal/documents{,/**}
+    peer=(name=org.freedesktop.portal.Documents),
+dbus (send)
+    bus=session
+    interface=org.freedesktop.DBus.Properties
+    path=/org/freedesktop/portal/documents{,/**}
+    peer=(name=org.freedesktop.portal.Documents),
 
 # These accesses are noisy and applications can't do anything with the found
 # icon files, so explicitly deny to silence the denials


### PR DESCRIPTION
It uses a different bus name from the desktop portal.
