### PR TITLE
interface: Allow access to org.freedesktop.DBus.ListActivatableNames via system-observe interface

### DIFF
--- a/interfaces/builtin/system_observe.go
+++ b/interfaces/builtin/system_observe.go
@@ -120,7 +120,7 @@ dbus (send)
     bus={session,system}
     path=/org/freedesktop/DBus
     interface=org.freedesktop.DBus
-    member=ListNames
+    member={ListNames,ListActivatableNames}
     peer=(label=unconfined),
 
 # Allow clients to obtain the DBus machine ID on common buses. We do not


### PR DESCRIPTION
org.freedesktop.DBus.ListNames is already allowed, and this is a related method.
