### PR TITLE
UCD-70: Changes to fix upower

### DIFF
--- a/interfaces/builtin/desktop_launch_test.go
+++ b/interfaces/builtin/desktop_launch_test.go
@@ -90,7 +90,7 @@ func (s *desktopLaunchSuite) TestInterfaces(c *C) {
 
 func (s *desktopLaunchSuite) TestStaticInfo(c *C) {
 	si := interfaces.StaticInfoOf(s.iface)
-	c.Assert(si.ImplicitOnCore, Equals, false)
+	c.Assert(si.ImplicitOnCore, Equals, true)
 	c.Assert(si.ImplicitOnClassic, Equals, true)
 	c.Assert(si.Summary, Equals, `allows snaps to identify and launch desktop applications in (or from) other snaps`)
 	c.Assert(si.BaseDeclarationSlots, testutil.Contains, "desktop-launch")

--- a/interfaces/builtin/upower_observe.go
+++ b/interfaces/builtin/upower_observe.go
@@ -167,7 +167,7 @@ dbus (send)
     path=/org/freedesktop/UPower
     interface=org.freedesktop.UPower
     member=EnumerateDevices
-    peer=(label=###SLOT_SECURITY_TAGS###),
+    peer=(label=unconfined),
 
 # Read all properties from UPower and devices
 # do not use peer=(label=unconfined) here since this is DBus activated
@@ -204,7 +204,7 @@ dbus (receive)
     path=/org/freedesktop/UPower{,/devices/**}
     interface=org.freedesktop.DBus.Properties
     member=PropertiesChanged
-    peer=(label=###SLOT_SECURITY_TAGS###),
+    peer=(label=unconfined),
 
 # Allow clients to introspect the service
 # do not use peer=(label=unconfined) here since this is DBus activated

--- a/interfaces/builtin/upower_observe.go
+++ b/interfaces/builtin/upower_observe.go
@@ -27,7 +27,6 @@ import (
 	"github.com/snapcore/snapd/interfaces/dbus"
 	"github.com/snapcore/snapd/interfaces/seccomp"
 	"github.com/snapcore/snapd/osutil"
-	"github.com/snapcore/snapd/release"
 	"github.com/snapcore/snapd/snap"
 )
 
@@ -167,7 +166,7 @@ dbus (send)
     path=/org/freedesktop/UPower
     interface=org.freedesktop.UPower
     member=EnumerateDevices
-    peer=(label=unconfined),
+    peer=(label=###SLOT_SECURITY_TAGS###),
 
 # Read all properties from UPower and devices
 # do not use peer=(label=unconfined) here since this is DBus activated
@@ -204,7 +203,7 @@ dbus (receive)
     path=/org/freedesktop/UPower{,/devices/**}
     interface=org.freedesktop.DBus.Properties
     member=PropertiesChanged
-    peer=(label=unconfined),
+    peer=(label=###SLOT_SECURITY_TAGS###),
 
 # Allow clients to introspect the service
 # do not use peer=(label=unconfined) here since this is DBus activated
@@ -233,7 +232,7 @@ func (iface *upowerObserveInterface) StaticInfo() interfaces.StaticInfo {
 func (iface *upowerObserveInterface) AppArmorConnectedPlug(spec *apparmor.Specification, plug *interfaces.ConnectedPlug, slot *interfaces.ConnectedSlot) error {
 	old := "###SLOT_SECURITY_TAGS###"
 	new := slotAppLabelExpr(slot)
-	if release.OnClassic {
+	if implicitSystemConnectedSlot(slot) {
 		// Let confined apps access unconfined upower on classic
 		new = "unconfined"
 	}

--- a/interfaces/builtin/utils.go
+++ b/interfaces/builtin/utils.go
@@ -100,8 +100,7 @@ func implicitSystemPermanentSlot(slot *snap.SlotInfo) bool {
 // isPermanentSlotSystemSlot(), the slot can be owned by the system or an
 // application.
 func implicitSystemConnectedSlot(slot *interfaces.ConnectedSlot) bool {
-	if release.OnClassic &&
-		(slot.Snap().Type() == snap.TypeOS || slot.Snap().Type() == snap.TypeSnapd) {
+	if slot.Snap().Type() == snap.TypeOS || slot.Snap().Type() == snap.TypeSnapd {
 		return true
 	}
 	return false
@@ -129,11 +128,12 @@ func verifySlotPathAttribute(slotRef *interfaces.SlotRef, attrs interfaces.Attre
 
 // aareExclusivePatterns takes a string and generates deny alternations. Eg,
 // aareExclusivePatterns("foo") returns:
-// []string{
-//   "[^f]*",
-//   "f[^o]*",
-//   "fo[^o]*",
-// }
+//
+//	[]string{
+//	  "[^f]*",
+//	  "f[^o]*",
+//	  "fo[^o]*",
+//	}
 func aareExclusivePatterns(orig string) []string {
 	// This function currently is only intended to be used with desktop
 	// prefixes as calculated by info.DesktopPrefix (the snap name and

--- a/interfaces/builtin/wayland_test.go
+++ b/interfaces/builtin/wayland_test.go
@@ -126,7 +126,7 @@ func (s *WaylandInterfaceSuite) TestAppArmorSpecOnClassic(c *C) {
 	spec := &apparmor.Specification{}
 	c.Assert(spec.AddConnectedPlug(s.iface, s.plug, s.classicSlot), IsNil)
 	c.Assert(spec.SecurityTags(), DeepEquals, []string{"snap.consumer.app"})
-	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "owner /run/user/[0-9]*/wayland-[0-9]* rw,")
+	c.Assert(spec.SnippetForTag("snap.consumer.app"), testutil.Contains, "owner /run/user/[0-9]*/{,*/}wayland-[0-9]* rw,")
 
 	// connected classic slot to plug
 	spec = &apparmor.Specification{}


### PR DESCRIPTION
This change allows to receive the change notifications from the devices.

After checking what was replaced by snapd in upower, I found that in the PC with normal Ubuntu, ###SLOT_SECURITY_TAGS### was replaced by "unconfined", but in Desktop Core it was replaced by "snap.SNAP-NAME.APP-NAME". Changing it to "unconfined" in the sources fixes "upower -m" and my test application.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
