### PR TITLE
desktop interface: Fix OpenURI in Core Desktop

### DIFF
--- a/interfaces/builtin/desktop.go
+++ b/interfaces/builtin/desktop.go
@@ -335,6 +335,11 @@ dbus (receive, send)
     path=/org/freedesktop/portal/desktop{,/**}
     interface=org.freedesktop.DBus.Properties
     peer=(label=unconfined),
+dbus (send)
+    bus=session
+    interface=org.freedesktop.portal.*
+    path=/org/freedesktop/portal/desktop{,/**}
+    peer=(label=unconfined),
 `
 
 type desktopInterface struct {


### PR DESCRIPTION
org.freedesktop.portal.OpenURI doesn’t work in core desktop. For example, opening Gnome Control Center->Privaty->Location Services and clicking on “Privacy Policy” doesn’t work.

This patch fixes it.

This patch is the upstream version of https://github.com/canonical/ubuntu-core-desktop-snapd/pull/17; but since the upstream snapd still lacks a slot for the desktop interface, I add it here.

Thanks for helping us make a better snapd!
Have you signed the [license agreement](https://www.ubuntu.com/legal/contributors) and read the [contribution guide](https://github.com/snapcore/snapd/blob/master/CONTRIBUTING.md)?
